### PR TITLE
Break when finding the infection

### DIFF
--- a/source/Patches/Utils.cs
+++ b/source/Patches/Utils.cs
@@ -225,6 +225,7 @@ namespace TownOfUs
                     if (player.PlayerId == impostor.Object.PlayerId)
                     {
                         isImpostor = true;
+                        break;
                     }
                 }
 
@@ -267,6 +268,7 @@ namespace TownOfUs
                     if (player.PlayerId == impostor.Object.PlayerId)
                     {
                         isImpostor = true;
+                        break;
                     }
                 }
 


### PR DESCRIPTION
Was poking at the code, and I think I found a minor optimization. `isImpostor` can only go from `false` to `true`. Once we've set it to `true`, we can save a few cycles and break out early.