### PR TITLE
Reduce minimum time rewind

### DIFF
--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -323,7 +323,7 @@ namespace TownOfUs.CustomOption
             TimeLord =
                 new CustomHeaderOption(num++, "<color=#0000FFFF>Time Lord</color>");
             RewindRevive = new CustomToggleOption(num++, "Revive During Rewind", false);
-            RewindDuration = new CustomNumberOption(num++, "Rewind Duration", 3f, 3f, 15f, 0.5f, CooldownFormat);
+            RewindDuration = new CustomNumberOption(num++, "Rewind Duration", 3f, 1.5f, 15f, 0.5f, CooldownFormat);
             RewindCooldown = new CustomNumberOption(num++, "Rewind Cooldown", 25f, 10f, 40f, 2.5f, CooldownFormat);
 
             TimeLordVitals =


### PR DESCRIPTION
Reducing minimum time rewind by a second and a half to help resolve the "Time Lord is too overpowered" issue.